### PR TITLE
Release 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,19 @@ Additionally, our client supports pephub authorization.
 The authorization process is based on pephub device authorization protocol.
 To upload projects or to download private projects, user must be authorized through pephub.
 
-If you want to use your own pephub instance, you can specify it by setting `PEPHUB_BASE_URL` environment variable.
-e.g. `export PEPHUB_BASE_URL=https://pephub.databio.org/` (This is original pephub instance)
+If you want to use your own pephub instance, you can specify it by setting the `PEPHUB_BASE_URL` environment variable.
+e.g. `export PEPHUB_BASE_URL=https://pephub.databio.org/` (This is the original pephub instance)
 
 To login, use the `login` argument; to logout, use `logout`.
+
+`login` accepts two optional arguments:
+- `--token` — register a JWT token directly, skipping the browser device-code flow.
+- `--url` — base URL of the pephub instance to authenticate against (overrides `PEPHUB_BASE_URL` for this login).
+
+e.g. `phc login --token <JWT> --url https://pephub.databio.org/`
+
+Credentials are cached in `$PH_HOME/jwt.toml`, which stores both the token and its base URL.
+`PH_HOME` defaults to `~/.pephubclient/`; set the `PH_HOME` environment variable to use a different directory.
 
 ----
 ```text

--- a/pephubclient/__init__.py
+++ b/pephubclient/__init__.py
@@ -4,7 +4,7 @@ import logging
 import coloredlogs
 
 __app_name__ = "pephubclient"
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 __author__ = "Oleksandr Khoroshevskyi, Rafal Stepien"
 
 

--- a/pephubclient/cli.py
+++ b/pephubclient/cli.py
@@ -11,11 +11,18 @@ app = typer.Typer()
 
 
 @app.command()
-def login():
+def login(
+    token: str = typer.Option(
+        None, help="JWT token from PEPhub. If provided, skips the browser login."
+    ),
+    url: str = typer.Option(
+        None, help="Base URL for PEPhub, if not using the default host."
+    ),
+):
     """
     Login to PEPhub
     """
-    call_client_func(_client.login)
+    call_client_func(_client.login, token=token, url=url)
 
 
 @app.command()

--- a/pephubclient/constants.py
+++ b/pephubclient/constants.py
@@ -4,13 +4,9 @@ import os
 
 from pydantic import BaseModel, field_validator
 
-PEPHUB_BASE_URL = os.getenv(
-    "PEPHUB_BASE_URL", default="https://pephub-api.databio.org/"
-)
+DEFAULT_BASE_URL = "https://pephub-api.databio.org/"
+PEPHUB_BASE_URL = os.getenv("PEPHUB_BASE_URL", default=DEFAULT_BASE_URL)
 # PEPHUB_BASE_URL = "http://0.0.0.0:8000/"
-PEPHUB_PEP_API_BASE_URL = f"{PEPHUB_BASE_URL}api/v1/projects/"
-PEPHUB_PEP_SEARCH_URL = f"{PEPHUB_BASE_URL}api/v1/namespaces/{{namespace}}/projects"
-PEPHUB_PUSH_URL = f"{PEPHUB_BASE_URL}api/v1/namespaces/{{namespace}}/projects/json"
 
 PEPHUB_SAMPLE_URL = f"{PEPHUB_BASE_URL}api/v1/projects/{{namespace}}/{{project}}/samples/{{sample_name}}"
 PEPHUB_VIEW_URL = (
@@ -31,6 +27,13 @@ class RegistryPath(BaseModel):
         return v or "default"
 
 
+class CachedToken(BaseModel):
+    """Credentials persisted to the TOML cache file."""
+
+    token: Optional[str] = None
+    base_url: str = DEFAULT_BASE_URL
+
+
 class ResponseStatusCodes(int, Enum):
     OK = 200
     ACCEPTED = 202
@@ -41,8 +44,12 @@ class ResponseStatusCodes(int, Enum):
     INTERNAL_ERROR = 500
 
 
-USER_DATA_FILE_NAME = "jwt.txt"
-HOME_PATH = os.getenv("HOME")
-if not HOME_PATH:
-    HOME_PATH = os.path.expanduser("~")
-PATH_TO_FILE_WITH_JWT = os.path.join(HOME_PATH, ".pephubclient/") + USER_DATA_FILE_NAME
+USER_DATA_FILE_NAME = "jwt.toml"
+
+PH_HOME = os.getenv("PH_HOME")
+if PH_HOME:
+    _CACHE_DIR = PH_HOME
+else:
+    HOME_PATH = os.getenv("HOME") or os.path.expanduser("~")
+    _CACHE_DIR = os.path.join(HOME_PATH, ".pephubclient")
+PATH_TO_TOKEN_FILE = os.path.join(_CACHE_DIR, USER_DATA_FILE_NAME)

--- a/pephubclient/files_manager.py
+++ b/pephubclient/files_manager.py
@@ -3,30 +3,33 @@ from contextlib import suppress
 from pathlib import Path
 
 import pandas
+import toml
 import yaml
 import zipfile
 
+from pephubclient.constants import CachedToken
 from pephubclient.exceptions import PEPExistsError
 
 
 class FilesManager:
     @staticmethod
-    def save_jwt_data_to_file(path: str, jwt_data: str) -> None:
+    def save_token_data(path: str, token: CachedToken) -> None:
         """
-        Save jwt to provided path
+        Save cached token data (jwt + base url) to provided path as TOML.
         """
         Path(os.path.dirname(path)).mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
-            f.write(jwt_data)
+            toml.dump(token.model_dump(), f)
 
     @staticmethod
-    def load_jwt_data_from_file(path: str) -> str:
+    def load_token_data(path: str) -> CachedToken:
         """
-        Open the file with username and ID and load this data.
+        Load cached token data from the TOML file, or return defaults if missing.
         """
         with suppress(FileNotFoundError):
             with open(path, "r") as f:
-                return f.read()
+                return CachedToken(**toml.load(f))
+        return CachedToken()
 
     @staticmethod
     def create_project_folder(

--- a/pephubclient/models.py
+++ b/pephubclient/models.py
@@ -11,8 +11,8 @@ class ProjectDict(BaseModel):
     """
 
     config: dict = Field(alias=CONFIG_KEY)
-    subsample_list: Optional[list] = Field(alias=SUBSAMPLE_RAW_LIST_KEY)
-    sample_list: list = Field(alias=SAMPLE_RAW_DICT_KEY)
+    subsamples: Optional[list] = Field(alias=SUBSAMPLE_RAW_LIST_KEY)
+    samples: list = Field(alias=SAMPLE_RAW_DICT_KEY)
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/pephubclient/pephub_oauth/const.py
+++ b/pephubclient/pephub_oauth/const.py
@@ -1,6 +1,4 @@
 # constants of pephub_auth
 
-from pephubclient.constants import PEPHUB_BASE_URL
-
-PEPHUB_DEVICE_INIT_URI = f"{PEPHUB_BASE_URL}auth/device/init"
-PEPHUB_DEVICE_TOKEN_URI = f"{PEPHUB_BASE_URL}auth/device/token"
+DEVICE_INIT_PATH = "auth/device/init"
+DEVICE_TOKEN_PATH = "auth/device/token"

--- a/pephubclient/pephub_oauth/pephub_oauth.py
+++ b/pephubclient/pephub_oauth/pephub_oauth.py
@@ -1,14 +1,15 @@
 import json
 import time
-from typing import Type, Union
+from typing import Optional, Type, Union
 
 import requests
 from pydantic import BaseModel
 
+from pephubclient.constants import DEFAULT_BASE_URL
 from pephubclient.helpers import MessageHandler, RequestManager
 from pephubclient.pephub_oauth.const import (
-    PEPHUB_DEVICE_INIT_URI,
-    PEPHUB_DEVICE_TOKEN_URI,
+    DEVICE_INIT_PATH,
+    DEVICE_TOKEN_PATH,
 )
 from pephubclient.pephub_oauth.exceptions import (
     PEPHubResponseException,
@@ -25,7 +26,8 @@ class PEPHubAuth(RequestManager):
     Class responsible for authorization to PEPhub.
     """
 
-    def login_to_pephub(self):
+    def login_to_pephub(self, base_url: Optional[str] = None):
+        self._base_url = (base_url or DEFAULT_BASE_URL).rstrip("/") + "/"
         pephub_response = self._request_pephub_for_device_code()
         print(
             f"User verification code: {pephub_response.device_code}, please go to the website: "
@@ -65,7 +67,7 @@ class PEPHubAuth(RequestManager):
         """
         response = PEPHubAuth.send_request(
             method="POST",
-            url=PEPHUB_DEVICE_INIT_URI,
+            url=f"{self._base_url}{DEVICE_INIT_PATH}",
             params=None,
             headers=None,
         )
@@ -78,7 +80,7 @@ class PEPHubAuth(RequestManager):
         """
         response = PEPHubAuth.send_request(
             method="POST",
-            url=PEPHUB_DEVICE_TOKEN_URI,
+            url=f"{self._base_url}{DEVICE_TOKEN_PATH}",
             params=None,
             headers={"device-code": device_code},
         )

--- a/pephubclient/pephubclient.py
+++ b/pephubclient/pephubclient.py
@@ -2,18 +2,20 @@ from typing import NoReturn, Optional, Literal
 from typing_extensions import deprecated
 
 import peppy
-from peppy.const import NAME_KEY, CONFIG_KEY
+from peppy.const import (
+    NAME_KEY,
+    CONFIG_KEY,
+    SUBSAMPLE_RAW_LIST_KEY,
+    SAMPLE_RAW_DICT_KEY,
+)
 import urllib3
 from pydantic import ValidationError
 from ubiquerg import parse_registry_path
 
 from pephubclient.constants import (
-    PEPHUB_PEP_API_BASE_URL,
-    PEPHUB_PUSH_URL,
     RegistryPath,
     ResponseStatusCodes,
-    PEPHUB_PEP_SEARCH_URL,
-    PATH_TO_FILE_WITH_JWT,
+    PATH_TO_TOKEN_FILE,
 )
 from pephubclient.exceptions import (
     IncorrectQueryStringError,
@@ -37,7 +39,9 @@ urllib3.disable_warnings()
 
 class PEPHubClient(RequestManager):
     def __init__(self):
-        self.__jwt_data = FilesManager.load_jwt_data_from_file(PATH_TO_FILE_WITH_JWT)
+        cached = FilesManager.load_token_data(PATH_TO_TOKEN_FILE)
+        self.__jwt_data = cached.token
+        self.__base_url = cached.base_url.rstrip("/") + "/"
 
         self.__view = PEPHubView(self.__jwt_data)
         self.__sample = PEPHubSample(self.__jwt_data)
@@ -55,20 +59,32 @@ class PEPHubClient(RequestManager):
     def schema(self) -> PEPHubSchema:
         return self.__schema
 
-    def login(self) -> NoReturn:
+    def login(self, token: Optional[str] = None, url: Optional[str] = None) -> NoReturn:
         """
-        Log in to PEPhub
-        """
-        user_token = PEPHubAuth().login_to_pephub()
+        Log in to PEPhub.
 
-        FilesManager.save_jwt_data_to_file(PATH_TO_FILE_WITH_JWT, user_token)
-        self.__jwt_data = FilesManager.load_jwt_data_from_file(PATH_TO_FILE_WITH_JWT)
+        :param str token: JWT token to register directly. If provided, the browser
+            device-code flow is skipped.
+        :param str url: Base URL for PEPhub. If provided, overrides the cached/default URL.
+        """
+        cached = FilesManager.load_token_data(PATH_TO_TOKEN_FILE)
+        if url:
+            cached.base_url = url
+        if token:
+            MessageHandler.print_warning("Token provided. Registering...")
+            cached.token = token
+        else:
+            cached.token = PEPHubAuth().login_to_pephub(base_url=cached.base_url)
+
+        FilesManager.save_token_data(PATH_TO_TOKEN_FILE, cached)
+        self.__jwt_data = cached.token
+        self.__base_url = cached.base_url.rstrip("/") + "/"
 
     def logout(self) -> NoReturn:
         """
         Log out from PEPhub
         """
-        FilesManager.delete_file_if_exists(PATH_TO_FILE_WITH_JWT)
+        FilesManager.delete_file_if_exists(PATH_TO_TOKEN_FILE)
         self.__jwt_data = None
 
     def pull(
@@ -174,6 +190,10 @@ class PEPHubClient(RequestManager):
         if name:
             pep_dict[CONFIG_KEY][NAME_KEY] = name
 
+        pep_dict["config"] = pep_dict.pop(CONFIG_KEY)
+        pep_dict["samples"] = pep_dict.pop(SAMPLE_RAW_DICT_KEY)
+        pep_dict["subsamples"] = pep_dict.pop(SUBSAMPLE_RAW_LIST_KEY)
+        print(pep_dict)
         upload_data = ProjectUploadData(
             pep_dict=pep_dict,
             tag=tag,
@@ -353,10 +373,11 @@ class PEPHubClient(RequestManager):
         variables_string = self.parse_query_param(query_param)
         endpoint += variables_string
 
-        return PEPHUB_PEP_API_BASE_URL + endpoint
+        return f"{self.__base_url}api/v1/projects/" + endpoint
 
-    @staticmethod
-    def _build_project_search_url(namespace: str, query_param: dict = None) -> str:
+    def _build_project_search_url(
+        self, namespace: str, query_param: dict = None
+    ) -> str:
         """
         Build request for searching projects form pephub
 
@@ -367,14 +388,13 @@ class PEPHubClient(RequestManager):
         variables_string = RequestManager.parse_query_param(query_param)
         endpoint = variables_string
 
-        return PEPHUB_PEP_SEARCH_URL.format(namespace=namespace) + endpoint
+        return f"{self.__base_url}api/v1/namespaces/{namespace}/projects" + endpoint
 
-    @staticmethod
-    def _build_push_request_url(namespace: str) -> str:
+    def _build_push_request_url(self, namespace: str) -> str:
         """
         Build project uplaod request used in pephub
 
         :param namespace: namespace where project will be uploaded
         :return: url string
         """
-        return PEPHUB_PUSH_URL.format(namespace=namespace)
+        return f"{self.__base_url}api/v1/namespaces/{namespace}/projects/json"

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -5,3 +5,4 @@ pydantic>2.5.0
 pandas>=2.0.0
 ubiquerg>=0.6.3
 coloredlogs>=15.0.1
+toml>=0.10.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,8 @@ def test_raw_pep_return():
             "description": "desc",
             "name": "sample name",
         },
-        "subsample_list": [],
-        "sample_list": [
+        "subsamples": [],
+        "samples": [
             {"time": "0", "file_path": "source1", "sample_name": "pig_0h"},
             {"time": "1", "file_path": "source1", "sample_name": "pig_1h"},
             {"time": "0", "file_path": "source1", "sample_name": "frog_0h"},

--- a/tests/test_pephubclient.py
+++ b/tests/test_pephubclient.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from pephubclient.constants import CachedToken
 from pephubclient.exceptions import ResponseError
 from pephubclient.pephubclient import PEPHubClient
 from pephubclient.helpers import is_registry_path
@@ -35,7 +36,7 @@ class TestSmoke:
         )
 
         pathlib_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.save_jwt_data_to_file"
+            "pephubclient.files_manager.FilesManager.save_token_data"
         )
 
         PEPHubClient().login()
@@ -45,6 +46,34 @@ class TestSmoke:
         assert pephub_exchange_code_mock.called
         assert pathlib_mock.called
 
+    def test_login_with_token_skips_device_flow(self, mocker, test_jwt):
+        """Providing a token registers it directly without the device flow."""
+        login_mock = mocker.patch(
+            "pephubclient.pephub_oauth.pephub_oauth.PEPHubAuth.login_to_pephub"
+        )
+        save_mock = mocker.patch(
+            "pephubclient.files_manager.FilesManager.save_token_data"
+        )
+
+        PEPHubClient().login(token=test_jwt, url="https://example.org/")
+
+        assert not login_mock.called
+        saved = save_mock.call_args.args[1]
+        assert saved.token == test_jwt
+        assert saved.base_url == "https://example.org/"
+
+    def test_login_url_passed_to_device_flow(self, mocker, test_jwt):
+        """Without a token, the url is forwarded to the device-code flow."""
+        login_mock = mocker.patch(
+            "pephubclient.pephub_oauth.pephub_oauth.PEPHubAuth.login_to_pephub",
+            return_value=test_jwt,
+        )
+        mocker.patch("pephubclient.files_manager.FilesManager.save_token_data")
+
+        PEPHubClient().login(url="https://example.org/")
+
+        login_mock.assert_called_once_with(base_url="https://example.org/")
+
     def test_logout(self, mocker):
         os_remove_mock = mocker.patch("os.remove")
         PEPHubClient().logout()
@@ -53,8 +82,8 @@ class TestSmoke:
 
     def test_pull(self, mocker, test_jwt, test_raw_pep_return):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -96,8 +125,8 @@ class TestSmoke:
         self, mocker, test_jwt, status_code, expected_error_message
     ):
         mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         mocker.patch(
             "requests.request",

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,4 +1,5 @@
 from pephubclient import PEPHubClient
+from pephubclient.constants import CachedToken
 from unittest.mock import Mock
 
 example_schema = {
@@ -26,8 +27,8 @@ versions_example = {
 class TestSchemas:
     def test_get_schema(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -47,8 +48,8 @@ class TestSchemas:
 
     def test_get_schema_versions(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -71,8 +72,8 @@ class TestSchemas:
 
     def test_create_schema(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -94,8 +95,8 @@ class TestSchemas:
 
     def test_update_schema(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -119,8 +120,8 @@ class TestSchemas:
 
     def test_delete_schema(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -139,8 +140,8 @@ class TestSchemas:
 
     def test_add_version(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -162,8 +163,8 @@ class TestSchemas:
 
     def test_update_version(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",
@@ -187,8 +188,8 @@ class TestSchemas:
 
     def test_delete_version(self, mocker, test_jwt):
         jwt_mock = mocker.patch(
-            "pephubclient.files_manager.FilesManager.load_jwt_data_from_file",
-            return_value=test_jwt,
+            "pephubclient.files_manager.FilesManager.load_token_data",
+            return_value=CachedToken(token=test_jwt),
         )
         requests_mock = mocker.patch(
             "requests.request",


### PR DESCRIPTION
This pull request introduces a more robust and flexible authentication and configuration system for the PEPhub client, with a focus on improved token management, support for per-login base URLs, and enhanced test coverage. The changes also include various code cleanups and updates to ensure consistency and future extensibility.

* Added support for logging in with a JWT token directly (`--token`) and specifying a base URL per login (`--url`). Credentials (token and base URL) are now cached in a TOML file (`jwt.toml`) in a configurable directory (`PH_HOME`). 
* The device authorization flow now respects the selected base URL, enabling authentication against different PEPhub instances. 
* Updated CLI and documentation to reflect new authentication options and credential storage. 
* Refactored internal constants and code to support dynamic base URLs throughout the client, including all project-related endpoints. 
* Introduced the `CachedToken` model for consistent credential serialization/deserialization. Updated file operations to use TOML for storing credentials.
* Changed default credential file from `jwt.txt` to `jwt.toml` and made the cache directory configurable via the `PH_HOME` environment variable. 
* Updated PEPhub endpoints urls, adjusting them to pephub 0.16.0 release