### PR TITLE
Move logging setup out of __init__.py

### DIFF
--- a/pephubclient/__init__.py
+++ b/pephubclient/__init__.py
@@ -1,7 +1,5 @@
 from pephubclient.pephubclient import PEPHubClient
 from pephubclient.helpers import is_registry_path, save_pep
-import logging
-import coloredlogs
 
 __app_name__ = "pephubclient"
 __version__ = "0.6.0"
@@ -16,11 +14,3 @@ __all__ = [
     "is_registry_path",
     "save_pep",
 ]
-
-
-_LOGGER = logging.getLogger(__app_name__)
-coloredlogs.install(
-    logger=_LOGGER,
-    datefmt="%H:%M:%S",
-    fmt="[%(levelname)s] [%(asctime)s] %(message)s",
-)

--- a/pephubclient/cli.py
+++ b/pephubclient/cli.py
@@ -1,3 +1,4 @@
+import logmuse
 import typer
 
 from pephubclient import __app_name__, __version__
@@ -94,8 +95,17 @@ def common(
     version: bool = typer.Option(
         None, "--version", "-v", callback=version_callback, help="App version"
     ),
+    verbosity: int = typer.Option(
+        None, "--verbosity", help="Set logging level: 1 (CRITICAL) to 5 (DEBUG)"
+    ),
+    logdev: bool = typer.Option(False, "--logdev", help="Use developer logging format"),
+    silent: bool = typer.Option(False, "--silent", help="Silence logging"),
 ):
-    pass
+    # This callback runs before any command, so it is where logging gets
+    # configured. Don't move this into `__init__.py`.
+    logmuse.init_logger(
+        __app_name__, verbosity=verbosity, devmode=logdev, silent=silent
+    )
 
 
 app.add_typer(schemas_app, name="schema")

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -5,4 +5,5 @@ pydantic>2.5.0
 pandas>=2.0.0
 ubiquerg>=0.6.3
 coloredlogs>=15.0.1
+logmuse>=0.3.1
 toml>=0.10.2


### PR DESCRIPTION
Importing pephubclient used to configure logging as a side effect. `__init__.py` called `coloredlogs.install()`, so anything that imported the package got a handler attached whether it wanted one or not, and got pephubclient's choice of format.

That belongs at the entry point instead, so the setup moved into the Typer callback, which runs before any command. This also adds `--verbosity`, `--logdev`, and `--silent`.

Output keeps the same shape it had, because logmuse 0.3.1 now uses `[%(levelname)s] [%(asctime)s] ...` as its default format. It also adds the logger name, so lines say where they came from:

    [INFO] [15:12:29] [pephubclient] Reading PEP from PEPhub...

Adds logmuse as a dependency, which pephubclient did not use before.